### PR TITLE
Refactor : 글 수정, 삭제시 아이디 검증 강화

### DIFF
--- a/RestBoard/src/main/java/com/my/restboard/application/Board/BoardController.java
+++ b/RestBoard/src/main/java/com/my/restboard/application/Board/BoardController.java
@@ -45,11 +45,11 @@ public class BoardController {
 
     @Operation(summary = "게시글 조회", description = "글번호를 이용하여 조회합니다.")
     @GetMapping("board")
-    public CommonResponse<?> readBoard(@RequestParam("board_num") Long board_num){
+    public CommonResponse<?> readBoard(@RequestParam("boardNum") Long boardNum){
 
         try{
 
-            BoardResponseDTO dto = service.read(board_num);
+            BoardResponseDTO dto = service.read(boardNum);
 
             CommonResponse response = CommonResponse.builder()
                     .success(true)
@@ -65,9 +65,9 @@ public class BoardController {
     }
 
     @Operation(summary = "게시글 수정", description = "글번호, 제목, 내용, 글의 아이디를 이용하여 수정합니다.")
-    @PutMapping("board/{board_num}")
+    @PutMapping("board/{boardNum}")
     public CommonResponse updateBoard( @AuthenticationPrincipal String userId,
-                                       @PathVariable Long board_num,
+                                       @PathVariable Long boardNum,
                                        @RequestBody BoardRequestDTO request) {
 
         try{
@@ -76,7 +76,7 @@ public class BoardController {
                 throw new RuntimeException("본인만 수정 할 수 있습니다.");
             }
 
-            Long return_num = service.update(board_num, request);
+            Long return_num = service.update(boardNum, userId, request);
 
             CommonResponse response = CommonResponse.builder()
                     .success(true)
@@ -92,8 +92,8 @@ public class BoardController {
     }
 
     @Operation(summary = "게시글 삭제", description = "글번호, 글의 아이디를 이용하여 삭제합니다.")
-    @DeleteMapping("board/{board_num}")
-    public CommonResponse deleteBoard(@AuthenticationPrincipal String userId, @PathVariable Long board_num,
+    @DeleteMapping("board/{boardNum}")
+    public CommonResponse deleteBoard(@AuthenticationPrincipal String userId, @PathVariable Long boardNum,
                                       @RequestBody String requestedId) {
 
         try{
@@ -102,7 +102,7 @@ public class BoardController {
                 throw new RuntimeException("본인만 삭제 할 수 있습니다.");
             }
 
-            service.delete(board_num);
+            service.delete(boardNum, userId);
 
             CommonResponse response = CommonResponse.builder()
                     .success(true)

--- a/RestBoard/src/main/java/com/my/restboard/application/Board/BoardEntity.java
+++ b/RestBoard/src/main/java/com/my/restboard/application/Board/BoardEntity.java
@@ -11,7 +11,7 @@ public class BoardEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long board_num;
+	private Long boardNum;
 
 	@Column(length = 200, nullable = false)
 	private String userId;

--- a/RestBoard/src/main/java/com/my/restboard/application/Board/BoardRepository.java
+++ b/RestBoard/src/main/java/com/my/restboard/application/Board/BoardRepository.java
@@ -1,7 +1,11 @@
 package com.my.restboard.application.Board;
 
+import com.my.restboard.application.User.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
 
+    Optional<BoardEntity> findByBoardNumAndUserId(Long boardNum, String userId);
 }

--- a/RestBoard/src/main/java/com/my/restboard/application/Board/BoardResponseDTO.java
+++ b/RestBoard/src/main/java/com/my/restboard/application/Board/BoardResponseDTO.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 @Getter
 public class BoardResponseDTO {
 
-    private Long board_num;
+    private Long boardNum;
     private String title;
     private String content;
     private String userId;
 
     public BoardResponseDTO(BoardEntity entity) {
-        this.board_num = entity.getBoard_num();
+        this.boardNum = entity.getBoardNum();
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.userId = entity.getUserId();

--- a/RestBoard/src/main/java/com/my/restboard/application/Board/BoardService.java
+++ b/RestBoard/src/main/java/com/my/restboard/application/Board/BoardService.java
@@ -20,13 +20,13 @@ public class BoardService {
 
 		createValidate(entity);
 
-		return repository.save(entity).getBoard_num();
+		return repository.save(entity).getBoardNum();
 	}
 
 	@Transactional(readOnly = true)
-	public BoardResponseDTO read(Long board_num) {
+	public BoardResponseDTO read(Long boardNum) {
 
-		Optional<BoardEntity> result = repository.findById(board_num);
+		Optional<BoardEntity> result = repository.findById(boardNum);
 
 		if (!result.isPresent()) {
 			throw new IllegalArgumentException("해당 하는 글이 없습니다");
@@ -38,9 +38,9 @@ public class BoardService {
 	}
 
 	@Transactional
-	public Long update(Long board_num, BoardRequestDTO requestDto) {
+	public Long update(Long boardNum, String userId, BoardRequestDTO requestDto) {
 
-		Optional<BoardEntity> result = repository.findById(board_num);
+		Optional<BoardEntity> result = repository.findByBoardNumAndUserId(boardNum, userId);
 
 		if (!result.isPresent()) {
 			throw new IllegalArgumentException("해당 하는 글이 없습니다");
@@ -50,13 +50,13 @@ public class BoardService {
 
 		entity.update(requestDto.getTitle(), requestDto.getContent());
 
-		return board_num;
+		return boardNum;
 	}
 
 	@Transactional
-	public void delete (Long board_num) {
+	public void delete (Long boardNum, String userId) {
 
-		Optional<BoardEntity> result = repository.findById(board_num);
+		Optional<BoardEntity> result = repository.findByBoardNumAndUserId(boardNum, userId);
 
 		if (!result.isPresent()) {
 			throw new IllegalArgumentException("해당 하는 글이 없습니다");

--- a/RestBoard/src/test/java/com/my/restboard/application/Board/BoardControllerTest.java
+++ b/RestBoard/src/test/java/com/my/restboard/application/Board/BoardControllerTest.java
@@ -83,9 +83,9 @@ public class BoardControllerTest {
 
         CommonResponse commonResponse = objectMapper.readValue(response, CommonResponse.class);
 
-        Long board_num = Long.valueOf((int)commonResponse.getData());
+        Long boardNum = Long.valueOf((int)commonResponse.getData());
 
-        BoardEntity entity  = repository.findById(board_num).get();
+        BoardEntity entity  = repository.findById(boardNum).get();
 
         assertThat(entity.getTitle()).isEqualTo(title);
         assertThat(entity.getContent()).isEqualTo(content);
@@ -103,7 +103,7 @@ public class BoardControllerTest {
                 .userId("admin")
                 .build());
 
-        Long board_num = createdEntity.getBoard_num();
+        Long boardNum = createdEntity.getBoardNum();
 
         String title = "수정제목";
         String content = "수정내용";
@@ -115,7 +115,7 @@ public class BoardControllerTest {
                 .userId(userId)
                 .build();
 
-        String url = "http://localhost:" + port + "/board/"+board_num;
+        String url = "http://localhost:" + port + "/board/"+boardNum;
 
         String response =  mvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -147,13 +147,13 @@ public class BoardControllerTest {
                 .userId("admin")
                 .build());
 
-        Long board_num = createdEntity.getBoard_num();
+        Long boardNum = createdEntity.getBoardNum();
 
         BoardRequestDTO requestDto = BoardRequestDTO.builder()
                 .userId("admin")
                 .build();
 
-        String url = "http://localhost:" + port + "/board/"+board_num;
+        String url = "http://localhost:" + port + "/board/"+boardNum;
 
         String response =  mvc.perform(delete(url)
                 .contentType(MediaType.APPLICATION_JSON_UTF8)


### PR DESCRIPTION
- 세부 리팩토링 내용 :  인증 된 유저의 아이디와 글번호에 해당하는 글 데이터가 존재하는지 먼저 조회한후에 삭제 및 수정하게끔 변경했다.
- 기존에는 프론트에서 넘어온 아이디와 인증된 아이디를 비교만 하고 넘어간 것 이라면 이제는 디비 조회까지 인증된 아이디를 사용하여 검증을 강화
- jpa 쿼리 메소드 활용